### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+ci:
+    autofix_prs: false
+    autoupdate_commit_msg: "ci: pre-commit auto-update"
+
+repos:
+
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.4.1
+      hooks:
+        - id: ruff
+          args: [ --fix ]
+        - id: ruff-format
+
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v1.9.0
+      hooks:
+          - id: mypy
+
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+          - id: check-added-large-files
+          - id: check-ast
+          - id: check-case-conflict
+          - id: check-merge-conflict
+          - id: end-of-file-fixer
+          - id: mixed-line-ending
+          - id: trailing-whitespace
+
+    - repo: https://github.com/pre-commit/pygrep-hooks
+      rev: v1.10.0
+      hooks:
+          - id: python-use-type-annotations
+          - id: rst-backticks
+          - id: rst-directive-colons
+          - id: rst-inline-touching-normal
+
+    - repo: https://github.com/PyCQA/doc8
+      rev: v1.1.1
+      hooks:
+          - id: doc8
+
+    - repo: https://github.com/regebro/pyroma
+      rev: "4.2"
+      hooks:
+          - id: pyroma
+            additional_dependencies: ["poetry"]

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from .staged_script.staged_script import (
     StagedScript,
     HelpFormatter,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Main requirements for `staged-script`.
+
+reverse-argparse
+rich
+tenacity

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from setuptools import setup
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ Setup file for the ``staged-script`` package.
 
 To install, simply ``python3 -m pip install .`` in the repository root.
 """
+
 from setuptools import setup
 
 setup(
@@ -16,5 +17,5 @@ setup(
     scripts=[],
     python_requires=">=3.10",
     tests_require=["pytest==7.1.1"],
-    install_requires=["rich==12.5.1"]
+    install_requires=["rich==12.5.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+"""
+Setup file for the ``staged-script`` package.
+
+To install, simply ``python3 -m pip install .`` in the repository root.
+"""
 from setuptools import setup
 
 setup(

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -1,3 +1,9 @@
+"""
+The ``staged-script`` package.
+
+Provide the :class:`StagedScript` class, along with some helper classes
+and functions.
+"""
 from .staged_script import (
     StagedScript,
     HelpFormatter,

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -4,6 +4,7 @@ The ``staged-script`` package.
 Provide the :class:`StagedScript` class, along with some helper classes
 and functions.
 """
+
 from .staged_script import (
     StagedScript,
     HelpFormatter,

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -1,4 +1,4 @@
-from .staged_script.staged_script import (
+from .staged_script import (
     StagedScript,
     HelpFormatter,
     RetryStage,

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -1001,7 +1001,7 @@ class StagedScript:
             or (print_command is None and self.print_commands is True)
         ):
             self.console.log(f"Executing:  {command}")
-        return subprocess.run(command, check=False, **kwargs)
+        return subprocess.run(command, check=False, **kwargs)  # noqa: S603
 
     #
     # Internal helper methods.

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import functools
 import re
 import shlex

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -232,10 +232,11 @@ class StagedScript:
             ValueError:  If the stage name is invalid.
         """
         if not re.match("^[a-z]+$", stage_name):
-            raise ValueError(
+            message = (
                 f"Stage name {stage_name!r} must contain only lowercase "
                 "letters."
             )
+            raise ValueError(message)
 
     #
     # Parse the command line arguments.

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -700,7 +700,7 @@ class StagedScript:
             StageDuration(self.current_stage, stage_duration)
         )  # yapf: disable
         self.console.log(
-            f"`{self.current_stage}` stage duration:  {str(stage_duration)}"
+            f"`{self.current_stage}` stage duration:  {stage_duration!s}"
         )
 
     def _run_post_stage_actions(self) -> None:

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -531,9 +531,9 @@ class StagedScript:
                 else:
                     try:
                         func(self, *args, **kwargs)
-                    except Exception as e:
+                    except Exception:
                         get_phase_method(self, "_end_stage")()
-                        raise e
+                        raise
                 get_phase_method(self, "_end_stage")()
 
             @functools.wraps(func)

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -168,6 +168,7 @@ class StagedScript:
     def __init__(
         self,
         stages: set[str],
+        *,
         console_force_terminal: bool | None = None,
         console_log_path: bool = True,
         print_commands: bool = True
@@ -959,6 +960,7 @@ class StagedScript:
     def run(
         self,
         command: str,
+        *,
         pretty_print: bool = False,
         print_command: bool | None = None,
         **kwargs

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -1001,7 +1001,7 @@ class StagedScript:
             or (print_command is None and self.print_commands is True)
         ):
             self.console.log(f"Executing:  {command}")
-        return subprocess.run(command, **kwargs)
+        return subprocess.run(command, check=False, **kwargs)
 
     #
     # Internal helper methods.

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -8,7 +8,6 @@ import functools
 import re
 import shlex
 import subprocess
-import sys
 from argparse import (
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
@@ -26,16 +25,11 @@ from rich.console import Console, Group
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.table import Table
+from reverse_argparse import ReverseArgumentParser, quote_arg_if_necessary
 from tenacity import RetryCallState, RetryError, Retrying, TryAgain
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt, stop_after_delay
 from tenacity.wait import wait_fixed
-
-sys.path.append(str(Path(__file__).resolve().parents[3] / "python"))
-from reverse_argparse import (  # noqa: E402
-    ReverseArgumentParser,
-    quote_arg_if_necessary
-)
 
 rich.traceback.install()
 

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -14,7 +14,7 @@ from argparse import (
     Namespace,
     RawDescriptionHelpFormatter
 )
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Callable, NamedTuple
@@ -210,10 +210,10 @@ class StagedScript:
         self.script_name = Path(__main__.__file__).name
         self.script_stem = Path(__main__.__file__).stem
         self.script_success = True
-        self.stage_start_time = datetime.now()
+        self.stage_start_time = datetime.now(tz=timezone.utc)
         self.stages = stages
         self.stages_to_run: set[str] = set()
-        self.start_time = datetime.now()
+        self.start_time = datetime.now(tz=timezone.utc)
 
     @staticmethod
     def _validate_stage_name(stage_name: str) -> None:
@@ -632,7 +632,7 @@ class StagedScript:
             heading:  A heading message to print indicating what will
                 happen in the stage.
         """
-        self.stage_start_time = datetime.now()
+        self.stage_start_time = datetime.now(tz=timezone.utc)
         self.print_heading(heading)
 
     def _skip_stage(self) -> None:
@@ -695,7 +695,7 @@ class StagedScript:
                 self._end_stage()  # Optional
                 # Insert more actions here.
         """
-        stage_duration = datetime.now() - self.stage_start_time
+        stage_duration = datetime.now(tz=timezone.utc) - self.stage_start_time
         self.durations.append(
             StageDuration(self.current_stage, stage_duration)
         )  # yapf: disable
@@ -1018,7 +1018,7 @@ class StagedScript:
         table.add_column(header="Stage", footer="Total")
         table.add_column(
             header="Duration",
-            footer=str(datetime.now() - self.start_time)
+            footer=str(datetime.now(tz=timezone.utc) - self.start_time)
         )
         for _ in self.durations:
             table.add_row(_.stage, str(_.duration))

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -53,13 +53,13 @@ def lazy_property(func: Callable) -> property:
     """
     attr_name = f"_lazy_{func.__name__}"
 
-    @property
+    @property  # type: ignore[misc]
     def _lazy_property(self):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, func(self))
         return getattr(self, attr_name)
 
-    return _lazy_property
+    return _lazy_property  # type: ignore[return-value]
 
 
 class StageDuration(NamedTuple):
@@ -471,7 +471,9 @@ class StagedScript:
             heading:  A heading message to print indicating what will
                 happen in the stage.
         """
-        __class__._validate_stage_name(stage_name)
+        __class__._validate_stage_name(  # type: ignore[name-defined]
+            stage_name
+        )
 
         def decorator(func: Callable) -> Callable:
             def get_phase_method(  # noqa: D417
@@ -494,7 +496,10 @@ class StagedScript:
                 custom_method = getattr(
                     self, f"{method_name}_{stage_name}", False
                 )
-                return custom_method or getattr(self, method_name)
+                return (
+                    custom_method  # type: ignore[return-value]
+                    or getattr(self, method_name)
+                )
 
             def run_retryable_phases(  # noqa: D417
                 self,
@@ -821,7 +826,7 @@ class StagedScript:
                 seconds=retry.statistics["delay_since_first_attempt"]
             )
             self.console.log(
-                self.print_heading(
+                self.print_heading(  # type: ignore[func-returns-value]
                     f"Abandoning retrying the {self.current_stage!r} stage.  "
                     f"Total attempts:  {retry.statistics['attempt_number']}.  "
                     f"Total time:  {stage_time}.",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,9 @@
+# Requirements for testing `staged-script`.
+
+mypy
+pre-commit
+pyroma
+pytest
+pytest-cov
+pytest-mock
+ruff

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -303,6 +303,6 @@ def test_raise_parser_error(
     with pytest.raises(SystemExit):
         ds.raise_parser_error(error_message)
     captured = capsys.readouterr()
-    expected = error_message.split() + ["usage:", "--dry-run", "--stage"]
+    expected = [*error_message.split(), "usage:", "--dry-run", "--stage"]
     for term in expected:
         assert term in captured.out

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -154,7 +154,7 @@ def test_get_timing_report(
 
 
 @pytest.mark.parametrize(
-    "command, expected",
+    ("command", "expected"),
     [("command --foo",
       "command \\\n    --foo"),
      ("command --foo bar baz",

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -1,3 +1,4 @@
+"""Unit tests for ``staged-script``."""
 import shlex
 from datetime import datetime, timedelta
 from subprocess import CompletedProcess
@@ -14,6 +15,7 @@ from python.staged_script.staged_script.staged_script import (
 
 @pytest.fixture()
 def ds() -> StagedScript:
+    """Create a :class:`StagedScript` object to be used by tests."""
     staged_script = StagedScript(set())
     staged_script.console = Console(log_time=False, log_path=False)
     return staged_script
@@ -23,6 +25,7 @@ def test_print_dry_run_message(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`print_dry_run_message` method."""
     message = "dry run message"
     expected = f"DRY-RUN MODE:  {message}"
     ds.print_dry_run_message(message)
@@ -31,6 +34,7 @@ def test_print_dry_run_message(
 
 
 def test_validate_stage_name() -> None:
+    """Test the :func:`validate_stage_name` method."""
     StagedScript._validate_stage_name("valid")
 
 
@@ -39,6 +43,7 @@ def test_validate_stage_name() -> None:
     ["Uppercase", "spa ces", "hyphen-ated", "under_scores"]
 )  # yapf: disable
 def test_validate_stage_name_raises(stage_name: str) -> None:
+    """Ensure :func:`validate_stage_name` raises an exception when needed."""
     with pytest.raises(ValueError) as e:
         StagedScript._validate_stage_name(stage_name)
     msg = e.value.args[0]
@@ -46,6 +51,7 @@ def test_validate_stage_name_raises(stage_name: str) -> None:
 
 
 def test__begin_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+    """Test the :func:`_begin_stage` method."""
     message = "begin stage"
     ds._begin_stage(message)
     captured = capsys.readouterr()
@@ -54,6 +60,7 @@ def test__begin_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
 
 
 def test__end_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+    """Test the :func:`_end_stage` method."""
     stage_name = "test"
     ds.current_stage = stage_name
     ds.stage_start_time = datetime.now()
@@ -65,6 +72,7 @@ def test__end_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
 
 
 def test__skip_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+    """Test the :func:`_skip_stage` method."""
     ds._skip_stage()
     captured = capsys.readouterr()
     assert "Skipping this stage." in captured.out
@@ -78,6 +86,7 @@ def test__handle_stage_retry_error(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`_handle_stage_retry_error` method."""
     ds.current_stage = "test"
     ds.test_retry_attempts = retry_attempts
     retry = mock_Retrying()
@@ -106,6 +115,7 @@ def test__prepare_to_retry_stage(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`_prepare_to_retry_stage` method."""
     ds.current_stage = "test"
     retry_state = mock_RetryCallState()
     retry_state.__repr__ = lambda self: "mock_RetryCallState.__repr__"
@@ -122,6 +132,7 @@ def test_get_timing_report(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`_get_timing_report` method."""
     ds.durations = [
         StageDuration(
             "first",
@@ -165,10 +176,12 @@ def test_pretty_print_command(
     expected: str,
     ds: StagedScript
 ) -> None:
+    """Test the :func:`pretty_print_command` method."""
     assert ds.pretty_print_command(command) == expected
 
 
 def test_parse_args(ds: StagedScript) -> None:
+    """Test the :func:`parse_args` method."""
     ds.stages = {"first", "second", "third"}
     ds.parse_args(shlex.split("--dry-run --stage first third"))
     assert ds.dry_run is True
@@ -183,6 +196,7 @@ def test_run(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`run` method."""
     command = "echo 'hello world'"
     mock_run.return_value = CompletedProcess(args=command, returncode=0)
     ds.print_commands = print_commands
@@ -201,6 +215,7 @@ def test_run_override_print_commands(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Ensure :func:`run` prints the command executed when appropriate."""
     command = "echo 'hello world'"
     mock_run.return_value = CompletedProcess(args=command, returncode=0)
     ds.run(command, print_command=False)
@@ -234,6 +249,7 @@ def test_print_script_execution_summary(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`print_script_execution_summary` method."""
     mock_get_pretty_command_line_invocation.return_value = (
         "command line invocation"
     )
@@ -278,6 +294,7 @@ def test_raise_parser_error(
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
+    """Test the :func:`raise_parser_error` method."""
     error_message = (
         "This is a lengthy error message explaining what exactly went wrong, "
         "where, and why.  It's so long it should get wrapped over multiple "

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -192,7 +192,7 @@ def test_parse_args(ds: StagedScript) -> None:
 @patch("subprocess.run")
 def test_run(
     mock_run: MagicMock,
-    print_commands: bool,
+    print_commands: bool,  # noqa: FBT001
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
@@ -245,7 +245,7 @@ def test_run_override_print_commands(
 def test_print_script_execution_summary(
     mock_get_pretty_command_line_invocation: MagicMock,
     extras: dict[str, str] | None,
-    script_success: bool,
+    script_success: bool,  # noqa: FBT001
     ds: StagedScript,
     capsys: pytest.CaptureFixture
 ) -> None:

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -1,6 +1,6 @@
 """Unit tests for ``staged-script``."""
 import shlex
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock, patch
 
@@ -64,7 +64,7 @@ def test__end_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
     """Test the :func:`_end_stage` method."""
     stage_name = "test"
     ds.current_stage = stage_name
-    ds.stage_start_time = datetime.now()
+    ds.stage_start_time = datetime.now(tz=timezone.utc)
     ds._end_stage()
     captured = capsys.readouterr()
     assert stage_name in [_.stage for _ in ds.durations]

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -1,4 +1,5 @@
 """Unit tests for ``staged-script``."""
+
 import shlex
 from datetime import datetime, timedelta, timezone
 from subprocess import CompletedProcess
@@ -9,7 +10,7 @@ from rich.console import Console
 
 from python.staged_script.staged_script.staged_script import (
     StagedScript,
-    StageDuration
+    StageDuration,
 )
 
 
@@ -22,8 +23,7 @@ def ds() -> StagedScript:
 
 
 def test_print_dry_run_message(
-    ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    ds: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`print_dry_run_message` method."""
     message = "dry run message"
@@ -85,7 +85,7 @@ def test__handle_stage_retry_error(
     mock_Retrying: MagicMock,
     retry_attempts: int,
     ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`_handle_stage_retry_error` method."""
     ds.current_stage = "test"
@@ -93,7 +93,7 @@ def test__handle_stage_retry_error(
     retry = mock_Retrying()
     retry.statistics = {
         "delay_since_first_attempt": 1234,
-        "attempt_number": retry_attempts
+        "attempt_number": retry_attempts,
     }
     ds._handle_stage_retry_error(retry)
     captured = capsys.readouterr()
@@ -105,7 +105,7 @@ def test__handle_stage_retry_error(
             "Total attempts:",
             "5.",
             "Total time:",
-            "0:20:34."
+            "0:20:34.",
         ]:
             assert text in captured.out
 
@@ -114,7 +114,7 @@ def test__handle_stage_retry_error(
 def test__prepare_to_retry_stage(
     mock_RetryCallState: MagicMock,
     ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`_prepare_to_retry_stage` method."""
     ds.current_stage = "test"
@@ -124,14 +124,13 @@ def test__prepare_to_retry_stage(
     captured = capsys.readouterr()
     for text in [
         "Preparing to retry the 'test' stage...",
-        "mock_RetryCallState.__repr__"
+        "mock_RetryCallState.__repr__",
     ]:
         assert text in captured.out
 
 
 def test_get_timing_report(
-    ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    ds: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`_get_timing_report` method."""
     ds.durations = [
@@ -155,25 +154,18 @@ def test_get_timing_report(
 
 @pytest.mark.parametrize(
     ("command", "expected"),
-    [("command --foo",
-      "command \\\n    --foo"),
-     ("command --foo bar baz",
-      "command \\\n    --foo bar \\\n    baz"),
-     ("command foo bar baz",
-      "command \\\n    foo \\\n    bar \\\n    baz"),
-     ("command --foo --bar baz",
-      "command \\\n    --foo \\\n    --bar baz"),
-     ("command --foo 'bar baz'",
-      "command \\\n    --foo 'bar baz'"),
-     ("command -f bar",
-      "command \\\n    -f \\\n    bar"),
-     ("command --foo -b",
-      "command \\\n    --foo \\\n    -b")]
+    [
+        ("command --foo", "command \\\n    --foo"),
+        ("command --foo bar baz", "command \\\n    --foo bar \\\n    baz"),
+        ("command foo bar baz", "command \\\n    foo \\\n    bar \\\n    baz"),
+        ("command --foo --bar baz", "command \\\n    --foo \\\n    --bar baz"),
+        ("command --foo 'bar baz'", "command \\\n    --foo 'bar baz'"),
+        ("command -f bar", "command \\\n    -f \\\n    bar"),
+        ("command --foo -b", "command \\\n    --foo \\\n    -b"),
+    ],
 )
 def test_pretty_print_command(
-    command: str,
-    expected: str,
-    ds: StagedScript
+    command: str, expected: str, ds: StagedScript
 ) -> None:
     """Test the :func:`pretty_print_command` method."""
     assert ds.pretty_print_command(command) == expected
@@ -193,7 +185,7 @@ def test_run(
     mock_run: MagicMock,
     print_commands: bool,  # noqa: FBT001
     ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`run` method."""
     command = "echo 'hello world'"
@@ -210,9 +202,7 @@ def test_run(
 
 @patch("subprocess.run")
 def test_run_override_print_commands(
-    mock_run: MagicMock,
-    ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    mock_run: MagicMock, ds: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Ensure :func:`run` prints the command executed when appropriate."""
     command = "echo 'hello world'"
@@ -232,10 +222,10 @@ def test_run_override_print_commands(
     [
         {
             "More information": "Additional details.",
-            "Another section": "With still more information."
+            "Another section": "With still more information.",
         },
-        None
-    ]
+        None,
+    ],
 )
 @patch(
     "reverse_argparse.ReverseArgumentParser."
@@ -246,7 +236,7 @@ def test_print_script_execution_summary(
     extras: dict[str, str] | None,
     script_success: bool,  # noqa: FBT001
     ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`print_script_execution_summary` method."""
     mock_get_pretty_command_line_invocation.return_value = (
@@ -273,7 +263,7 @@ def test_print_script_execution_summary(
         "Ran the following",
         "Commands executed",
         "Timing results",
-        "Script result"
+        "Script result",
     ]
     details = (
         [mock_get_pretty_command_line_invocation.return_value]
@@ -290,8 +280,7 @@ def test_print_script_execution_summary(
 
 
 def test_raise_parser_error(
-    ds: StagedScript,
-    capsys: pytest.CaptureFixture
+    ds: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`raise_parser_error` method."""
     error_message = (

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -44,10 +44,11 @@ def test_validate_stage_name() -> None:
 )  # yapf: disable
 def test_validate_stage_name_raises(stage_name: str) -> None:
     """Ensure :func:`validate_stage_name` raises an exception when needed."""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(
+        ValueError,
+        match=f"'{stage_name}' must contain only lowercase letters",
+    ):
         StagedScript._validate_stage_name(stage_name)
-    msg = e.value.args[0]
-    assert f"'{stage_name}' must contain only lowercase letters" in msg
 
 
 def test__begin_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -163,8 +163,6 @@ def test_get_timing_report(
       "command \\\n    foo \\\n    bar \\\n    baz"),
      ("command --foo --bar baz",
       "command \\\n    --foo \\\n    --bar baz"),
-     ("command foo bar baz",
-      "command \\\n    foo \\\n    bar \\\n    baz"),
      ("command --foo 'bar baz'",
       "command \\\n    --foo 'bar baz'"),
      ("command -f bar",

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import shlex
 from datetime import datetime, timedelta
 from subprocess import CompletedProcess

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -17,7 +17,7 @@ class MyAdvancedScript(StagedScript):
     """
 
     @StagedScript.stage("test", "Test stage")
-    def run_test(self, retry: bool = False) -> None:
+    def run_test(self, *, retry: bool = False) -> None:
         """
         A stage that might need to be retried.
 
@@ -67,6 +67,7 @@ def mas() -> MyAdvancedScript:
 def ensure_phase_comes_next(
     method_name: str,
     output: str,
+    *,
     custom: bool = False,
     start: int = 0
 ) -> int:
@@ -101,11 +102,11 @@ def ensure_phase_comes_next(
 @pytest.mark.parametrize("stages_to_run", [{"test"}, set()])
 def test_stage(
     stages_to_run: set[str],
-    custom_pre_stage: bool,
-    custom_begin_stage: bool,
-    custom_skip_stage: bool,
-    custom_end_stage: bool,
-    custom_post_stage: bool,
+    custom_pre_stage: bool,  # noqa: FBT001
+    custom_begin_stage: bool,  # noqa: FBT001
+    custom_skip_stage: bool,  # noqa: FBT001
+    custom_end_stage: bool,  # noqa: FBT001
+    custom_post_stage: bool,  # noqa: FBT001
     mas: MyAdvancedScript,
     capsys: pytest.CaptureFixture
 ) -> None:
@@ -160,8 +161,8 @@ def test_stage(
 @pytest.mark.parametrize("custom_handle_retry_error", [True, False])
 @pytest.mark.parametrize("custom_prepare_to_retry", [True, False])
 def test_stage_retry(
-    custom_prepare_to_retry: bool,
-    custom_handle_retry_error: bool,
+    custom_prepare_to_retry: bool,  # noqa: FBT001
+    custom_handle_retry_error: bool,  # noqa: FBT001
     retry_attempts: int,
     mas: MyAdvancedScript,
     capsys: pytest.CaptureFixture

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import shlex
 
 import pytest

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -213,7 +213,7 @@ def test_stage_retry(
             start=index
         )
     if retry_attempts == 0:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="substring not found"):
             ensure_phase_comes_next(
                 "_prepare_to_retry_stage",
                 captured.out,

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -1,4 +1,5 @@
 """Integration tests for an advanced ``staged-script`` use case."""
+
 import shlex
 
 import pytest
@@ -47,10 +48,7 @@ class MyAdvancedScript(StagedScript):
     def _run_post_stage_actions(self) -> None:
         print("inside '_run_post_stage_actions' function")
 
-    def _handle_stage_retry_error(
-        self,
-        retry: Retrying
-    ) -> None:
+    def _handle_stage_retry_error(self, retry: Retrying) -> None:
         print("inside '_handle_stage_retry_error' function")
 
     def _prepare_to_retry_stage(self, retry_state: RetryCallState) -> None:
@@ -66,11 +64,7 @@ def mas() -> MyAdvancedScript:
 
 
 def ensure_phase_comes_next(
-    method_name: str,
-    output: str,
-    *,
-    custom: bool = False,
-    start: int = 0
+    method_name: str, output: str, *, custom: bool = False, start: int = 0
 ) -> int:
     """
     A helper to check the sequencing of the output.
@@ -89,7 +83,8 @@ def ensure_phase_comes_next(
         The index of the phase output text in the output string.
     """
     search_text = (
-        f"inside '{method_name}_test' function" if custom
+        f"inside '{method_name}_test' function"
+        if custom
         else f"inside '{method_name}' function"
     )
     return output.index(search_text, start)
@@ -109,7 +104,7 @@ def test_stage(  # noqa: PLR0913
     custom_end_stage: bool,  # noqa: FBT001
     custom_post_stage: bool,  # noqa: FBT001
     mas: MyAdvancedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """
     Ensure the various phases of the stage run in the appropriate order.
@@ -119,24 +114,24 @@ def test_stage(  # noqa: PLR0913
     mas.parse_args([])
     mas.stages_to_run = stages_to_run
     if custom_pre_stage:
-        mas._run_pre_stage_actions_test = (
-            lambda: print("inside '_run_pre_stage_actions_test' function")
+        mas._run_pre_stage_actions_test = lambda: print(
+            "inside '_run_pre_stage_actions_test' function"
         )
     if custom_begin_stage:
-        mas._begin_stage_test = (
-            lambda heading: print("inside '_begin_stage_test' function")
+        mas._begin_stage_test = lambda heading: print(
+            "inside '_begin_stage_test' function"
         )
     if custom_skip_stage:
-        mas._skip_stage_test = (
-            lambda: print("inside '_skip_stage_test' function")
+        mas._skip_stage_test = lambda: print(
+            "inside '_skip_stage_test' function"
         )
     if custom_end_stage:
-        mas._end_stage_test = (
-            lambda: print("inside '_end_stage_test' function")
+        mas._end_stage_test = lambda: print(
+            "inside '_end_stage_test' function"
         )
     if custom_post_stage:
-        mas._run_post_stage_actions_test = (
-            lambda: print("inside '_run_post_stage_actions_test' function")
+        mas._run_post_stage_actions_test = lambda: print(
+            "inside '_run_post_stage_actions_test' function"
         )
     mas.run_test()
     captured = capsys.readouterr()
@@ -144,17 +139,17 @@ def test_stage(  # noqa: PLR0913
     phases = [
         ("_run_pre_stage_actions", custom_pre_stage),
         ("_begin_stage", custom_begin_stage),
-        (("run_test", False) if "test" in stages_to_run
-         else ("_skip_stage", custom_skip_stage)),
+        (
+            ("run_test", False)
+            if "test" in stages_to_run
+            else ("_skip_stage", custom_skip_stage)
+        ),
         ("_end_stage", custom_end_stage),
-        ("_run_post_stage_actions", custom_post_stage)
+        ("_run_post_stage_actions", custom_post_stage),
     ]
     for method, custom in phases:
         index = ensure_phase_comes_next(
-            method,
-            captured.out,
-            custom=custom,
-            start=index
+            method, captured.out, custom=custom, start=index
         )
 
 
@@ -166,7 +161,7 @@ def test_stage_retry(
     custom_handle_retry_error: bool,  # noqa: FBT001
     retry_attempts: int,
     mas: MyAdvancedScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """
     Ensure the various phases of the stage run in the appropriate order.
@@ -176,14 +171,12 @@ def test_stage_retry(
     mas.parse_args(shlex.split(f"--test-retry-attempts {retry_attempts}"))
     mas.stages_to_run = {"test"}
     if custom_prepare_to_retry:
-        mas._prepare_to_retry_stage_test = (
-            lambda retry_state:
-                print("inside '_prepare_to_retry_stage_test' function")
+        mas._prepare_to_retry_stage_test = lambda retry_state: print(
+            "inside '_prepare_to_retry_stage_test' function"
         )
     if custom_handle_retry_error:
-        mas._handle_stage_retry_error_test = (
-            lambda retry:
-                print("inside '_handle_stage_retry_error_test' function")
+        mas._handle_stage_retry_error_test = lambda retry: print(
+            "inside '_handle_stage_retry_error_test' function"
         )
     mas.run_test(retry=True)
     captured = capsys.readouterr()
@@ -192,25 +185,22 @@ def test_stage_retry(
         ("_run_pre_stage_actions", False),
         ("_begin_stage", False),
         ("run_test", False),
-        ("_end_stage", False)
+        ("_end_stage", False),
     ]
     for _ in range(retry_attempts):
         phases += [
             ("_prepare_to_retry_stage", custom_prepare_to_retry),
             ("_begin_stage", False),
             ("run_test", False),
-            ("_end_stage", False)
+            ("_end_stage", False),
         ]
     phases += [
         ("_handle_stage_retry_error", custom_handle_retry_error),
-        ("_run_post_stage_actions", False)
+        ("_run_post_stage_actions", False),
     ]
     for method, custom in phases:
         index = ensure_phase_comes_next(
-            method,
-            captured.out,
-            custom=custom,
-            start=index
+            method, captured.out, custom=custom, start=index
         )
     if retry_attempts == 0:
         with pytest.raises(ValueError, match="substring not found"):
@@ -218,5 +208,5 @@ def test_stage_retry(
                 "_prepare_to_retry_stage",
                 captured.out,
                 custom=custom_prepare_to_retry,
-                start=0
+                start=0,
             )

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -29,7 +29,8 @@ class MyAdvancedScript(StagedScript):
         """
         print("inside 'run_test' function")
         if retry:
-            raise TryAgain("Stage failed; retrying...")
+            message = "Stage failed; retrying..."
+            raise TryAgain(message)
 
     def _run_pre_stage_actions(self) -> None:
         print("inside '_run_pre_stage_actions' function")

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -101,7 +101,7 @@ def ensure_phase_comes_next(
 @pytest.mark.parametrize("custom_begin_stage", [True, False])
 @pytest.mark.parametrize("custom_pre_stage", [True, False])
 @pytest.mark.parametrize("stages_to_run", [{"test"}, set()])
-def test_stage(
+def test_stage(  # noqa: PLR0913
     stages_to_run: set[str],
     custom_pre_stage: bool,  # noqa: FBT001
     custom_begin_stage: bool,  # noqa: FBT001

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -1,4 +1,5 @@
 """Integration tests for a basic ``StagedScript`` use case."""
+
 import pytest
 from rich.console import Console
 
@@ -42,9 +43,7 @@ def mbs() -> MyBasicScript:
 
 @pytest.mark.parametrize("stages_to_run", [{"good"}, set()])
 def test_good_stage(
-    stages_to_run: set[str],
-    mbs: MyBasicScript,
-    capsys: pytest.CaptureFixture
+    stages_to_run: set[str], mbs: MyBasicScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Ensure the good stage runs to completion."""
     mbs.parse_args([])
@@ -69,7 +68,7 @@ def test_good_stage(
 def test_bad_stage(
     error: bool,  # noqa: FBT001
     mbs: MyBasicScript,
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """
     Ensure the bad stage runs as expected.

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -27,7 +27,8 @@ class MyBasicScript(StagedScript):
             error:  Whether an error should occur.
         """
         if error:
-            raise RuntimeError("Something went wrong.")
+            message = "Something went wrong."
+            raise RuntimeError(message)
         print("Got past error.")
 
 

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -19,7 +19,7 @@ class MyBasicScript(StagedScript):
         print("inside 'run_good_stage' function")
 
     @StagedScript.stage("bad", "Stage that throws an exception")
-    def run_bad_stage(self, error: bool) -> None:
+    def run_bad_stage(self, *, error: bool) -> None:
         """
         A simple stage that might run into an error.
 
@@ -66,7 +66,7 @@ def test_good_stage(
 
 @pytest.mark.parametrize("error", [True, False])
 def test_bad_stage(
-    error: bool,
+    error: bool,  # noqa: FBT001
     mbs: MyBasicScript,
     capsys: pytest.CaptureFixture
 ) -> None:
@@ -80,11 +80,11 @@ def test_bad_stage(
     mbs.stages_to_run = {"bad"}
     if error:
         with pytest.raises(RuntimeError) as e:
-            mbs.run_bad_stage(error)
+            mbs.run_bad_stage(error=error)
         msg = e.value.args[0]
         assert "Something went wrong." in msg
     else:
-        mbs.run_bad_stage(error)
+        mbs.run_bad_stage(error=error)
     captured = capsys.readouterr()
 
     # Ensure `_begin_stage()` is called.

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import pytest
 from rich.console import Console
 

--- a/test/test_staged_script_registered_stages.py
+++ b/test/test_staged_script_registered_stages.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from python.staged_script.staged_script.staged_script import StagedScript
 
 

--- a/test/test_staged_script_registered_stages.py
+++ b/test/test_staged_script_registered_stages.py
@@ -1,11 +1,13 @@
+"""Integration tests for retry options."""
 from python.staged_script.staged_script.staged_script import StagedScript
 
 
 class MyScript(StagedScript):
-    ...
+    """A basic staged script to test the retry options in the help text."""
 
 
 def test_parser_registered_stages() -> None:
+    """Ensure retry options are in the help text for all registered stages."""
     stages = {"one", "two", "three"}
     script = MyScript(stages)
     help_text = script.parser.format_help()
@@ -21,6 +23,7 @@ def test_parser_registered_stages() -> None:
 
 
 def test_parser_no_registered_stages() -> None:
+    """Ensure retry options are absent when no stages are registered."""
     script = MyScript(set())
     help_text = script.parser.format_help()
     for text in [

--- a/test/test_staged_script_registered_stages.py
+++ b/test/test_staged_script_registered_stages.py
@@ -1,4 +1,5 @@
 """Integration tests for retry options."""
+
 from python.staged_script.staged_script.staged_script import StagedScript
 
 
@@ -16,7 +17,7 @@ def test_parser_registered_stages() -> None:
         expected += [
             f"{stage}-retry-attempts",
             f"{stage}-retry-delay",
-            f"{stage}-retry-timeout"
+            f"{stage}-retry-timeout",
         ]
     for text in expected:
         assert text in help_text
@@ -27,8 +28,7 @@ def test_parser_no_registered_stages() -> None:
     script = MyScript(set())
     help_text = script.parser.format_help()
     for text in [
-        "Options for retrying stages"
-        "-retry-attempts",
+        "Options for retrying stages" "-retry-attempts",
         "-retry-delay",
         "-retry-timeout",
     ]:


### PR DESCRIPTION
**Type:  Task**

## Description
Add a pre-commit configuration and handle any necessary refactorings to make all the checks pass.

## Commits
1. **chore: Add requirements files** (0dc5512f072c9da26506fb3107ae244f38188a10)
1. **ci: Add pre-commit configuration** (d4823f42b4cf436bfbf67a3839236ae4e60859fc)
1. **chore: Remove unnecessary shebang lines** (3516d846d50894d6cec9d6365bd6a807c566596c)
1. **chore: Move __init__.py** (ba94a171396fc05795e9aa9dd7fa372aac34ee49)
1. **docs: Fix docstring issues** (7365c87fdc5896677f64c6f906955da93c334fbb)
1. **chore: Use installed reverse_argparse** (7a3d1b734a40acd92b2c8d05f04fb21489681644)
1. **refactor!: Make boolean parameters keyword-only** (2f3098f8d20e3ab306bc98654d351f9608ad3193)
1. **refactor: Save exception messages to variable** (27153901503919e09065b45b32322119d3e6ca28)
1. **refactor: Re-raise exception correctly** (889645d21b727484074c91adcf9303588763d711)
1. **style: Use f-string conversion flag** (56b2c4509bf29de11313b2c03c9d89d011389975)
1. **style: User iterable unpacking** (9b18fac70182c84d7d26bb9ae2aa8840dd03c981)
1. **refactor: Explicitly don't check for errors** (ed9d050ed6bd374351bd43b740827d1a4eb5758e)
1. **style: Match exception message** (c2353bd1fa327ddc2e5e0e317c80a755493f9cff)
1. **style: Pytest parametrize tuple** (02116440f957c59f77f008dc461371788dc0f1ce)
1. **test: Remove duplicate test case** (176bb6f241564d8833658052966f7d560edcf133)
1. **test: Disable warning on too many parametrizations** (99e59d9fa80f2c0764583b04556ff4655e399d1a)
1. **refactor: Specify UTC timezone** (1a95cd0050d6a2edb39287f185a360555436ff21)
1. **chore: Ignore unchecked shell input** (520b68e18c7e492ecec529d4d0a64e2f04b180af)

   When we built the precursor to `staged-script`, we didn't understand the security implications of having the user pass commands to the underlying shell as a string rather than a list of strings.  It just seemed like a better interface, to make it easy for the user writing their Python scripts to simply wrap their bash commands.  However, this opens up a danger for bad actors to cause problems via command injection.  We can remove the vulnerability by switching to only allowing a list of strings as input to `run()`, but that breaking change will need to wait till another day when I have more time available.
1. **style: Automatically format the code base** (241318690718a23368af69680e347b02b4a2062d)