### PR TITLE
Minor tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,7 @@ Setup file for the ``staged-script`` package.
 To install, simply ``python3 -m pip install .`` in the repository root.
 """
 
-from setuptools import setup
+import setuptools
 
-setup(
-    name="staged-script",
-    version="1.0.0",
-    description=(
-        "A base class to inherit from when building scripts that are "
-        "subdivided into a series of stages."
-    ),
-    packages=["staged_script"],
-    scripts=[],
-    python_requires=">=3.10",
-    tests_require=["pytest==7.1.1"],
-    install_requires=["rich==12.5.1"],
-)
+if __name__ == "__main__":
+    setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ Setup file for the ``staged-script`` package.
 To install, simply ``python3 -m pip install .`` in the repository root.
 """
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import setuptools
 
 if __name__ == "__main__":

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -20,3 +20,4 @@ __all__ = [
     "StageDuration",
     "lazy_property",
 ]
+__version__ = "1.0.0"

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -5,6 +5,12 @@ Provide the :class:`StagedScript` class, along with some helper classes
 and functions.
 """
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .staged_script import (
     StagedScript,
     HelpFormatter,

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -5,6 +5,12 @@ Provides the :class:`StagedScript` base class to extend when creating
 your own staged scripts, along with some helpers.
 """
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import functools
 import re
 import shlex

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -699,7 +699,7 @@ class StagedScript:
         stage_duration = datetime.now(tz=timezone.utc) - self.stage_start_time
         self.durations.append(
             StageDuration(self.current_stage, stage_duration)
-        )  # yapf: disable
+        )
         self.console.log(
             f"`{self.current_stage}` stage duration:  {stage_duration!s}"
         )
@@ -862,9 +862,11 @@ class StagedScript:
         args = shlex.split(command)
         lines = [args.pop(0)]
         while args:
-            if (not self._current_arg_is_long_flag(args)
-                    or self._next_arg_is_flag(args)
-                    or len(args) == 1):  # yapf: disable
+            if (
+                not self._current_arg_is_long_flag(args)
+                or self._next_arg_is_flag(args)
+                or len(args) == 1
+            ):
                 lines.append(args.pop(0))
             else:
                 lines.append(
@@ -887,9 +889,9 @@ class StagedScript:
         self.console.log(
             Padding(
                 Panel(f"DRY-RUN MODE:  {message}", style="yellow"),
-                (0, 0, 0, indent)
+                (0, 0, 0, indent),
             )
-        )  # yapf: disable
+        )
 
     def print_heading(self, message: str, *, color: str = "cyan") -> None:
         """
@@ -904,9 +906,8 @@ class StagedScript:
         self.console.log(Panel(f"[bold]{message}", style=color))
 
     def print_script_execution_summary(
-        self,
-        extra_sections: dict[str, str] | None = None
-    ) -> None:  # yapf: disable
+        self, extra_sections: dict[str, str] | None = None
+    ) -> None:
         """
         Print a summary of everything that was done by the script.
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,3 +5,9 @@ This ``__init__.py`` file creates the ``test`` package, such that tests
 can relative-import from modules in the sibling ``staged_script``
 directory.
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,7 @@
+"""
+Create the ``test`` package.
+
+This ``__init__.py`` file creates the ``test`` package, such that tests
+can relative-import from modules in the sibling ``staged_script``
+directory.
+"""

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -8,10 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rich.console import Console
 
-from python.staged_script.staged_script.staged_script import (
-    StagedScript,
-    StageDuration,
-)
+from staged_script import StagedScript, StageDuration
 
 
 @pytest.fixture()

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -1,5 +1,11 @@
 """Unit tests for ``staged-script``."""
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import shlex
 from datetime import datetime, timedelta, timezone
 from subprocess import CompletedProcess

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -97,7 +97,7 @@ def test__handle_stage_retry_error(
 ) -> None:
     """Test the :func:`_handle_stage_retry_error` method."""
     script.current_stage = "test"
-    script.test_retry_attempts = retry_attempts
+    script.test_retry_attempts = retry_attempts  # type: ignore[attr-defined]
     retry = mock_Retrying()
     retry.statistics = {
         "delay_since_first_attempt": 1234,

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -39,9 +39,8 @@ def test__validate_stage_name() -> None:
 
 
 @pytest.mark.parametrize(
-    "stage_name",
-    ["Uppercase", "spa ces", "hyphen-ated", "under_scores"]
-)  # yapf: disable
+    "stage_name", ["Uppercase", "spa ces", "hyphen-ated", "under_scores"]
+)
 def test__validate_stage_name_raises(stage_name: str) -> None:
     """Ensure :func:`validate_stage_name` raises an exception when needed."""
     with pytest.raises(
@@ -141,14 +140,12 @@ def test__get_timing_report(
     """Test the :func:`_get_timing_report` method."""
     script.durations = [
         StageDuration(
-            "first",
-            timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
+            "first", timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
         ),
         StageDuration(
-            "second",
-            timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
-        )
-    ]  # yapf: disable
+            "second", timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
+        ),
+    ]
     script.console.print(script._get_timing_report())
     captured = capsys.readouterr()
     for stage in [_.stage for _ in script.durations]:
@@ -250,14 +247,12 @@ def test_print_script_execution_summary(
     )
     script.durations = [
         StageDuration(
-            "first",
-            timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
+            "first", timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
         ),
         StageDuration(
-            "second",
-            timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
-        )
-    ]  # yapf: disable
+            "second", timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
+        ),
+    ]
     script.commands_executed = ["foo", "bar", "baz"]
     script.script_success = script_success
     if extras is None:
@@ -277,7 +272,7 @@ def test_print_script_execution_summary(
         + [_.stage for _ in script.durations]
         + [str(_.duration) for _ in script.durations]
         + ["Success" if script_success else "Failure"]
-    )  # yapf: disable
+    )
     if extras is not None:
         headings += list(extras.keys())
         details += list(extras.values())

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -15,7 +15,7 @@ from python.staged_script.staged_script.staged_script import (
 
 
 @pytest.fixture()
-def ds() -> StagedScript:
+def script() -> StagedScript:
     """Create a :class:`StagedScript` object to be used by tests."""
     staged_script = StagedScript(set())
     staged_script.console = Console(log_time=False, log_path=False)
@@ -23,12 +23,12 @@ def ds() -> StagedScript:
 
 
 def test_print_dry_run_message(
-    ds: StagedScript, capsys: pytest.CaptureFixture
+    script: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`print_dry_run_message` method."""
     message = "dry run message"
     expected = f"DRY-RUN MODE:  {message}"
-    ds.print_dry_run_message(message)
+    script.print_dry_run_message(message)
     captured = capsys.readouterr()
     assert expected in captured.out
 
@@ -51,30 +51,36 @@ def test_validate_stage_name_raises(stage_name: str) -> None:
         StagedScript._validate_stage_name(stage_name)
 
 
-def test__begin_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+def test__begin_stage(
+    script: StagedScript, capsys: pytest.CaptureFixture
+) -> None:
     """Test the :func:`_begin_stage` method."""
     message = "begin stage"
-    ds._begin_stage(message)
+    script._begin_stage(message)
     captured = capsys.readouterr()
     assert message in captured.out
-    assert ds.stage_start_time is not None
+    assert script.stage_start_time is not None
 
 
-def test__end_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+def test__end_stage(
+    script: StagedScript, capsys: pytest.CaptureFixture
+) -> None:
     """Test the :func:`_end_stage` method."""
     stage_name = "test"
-    ds.current_stage = stage_name
-    ds.stage_start_time = datetime.now(tz=timezone.utc)
-    ds._end_stage()
+    script.current_stage = stage_name
+    script.stage_start_time = datetime.now(tz=timezone.utc)
+    script._end_stage()
     captured = capsys.readouterr()
-    assert stage_name in [_.stage for _ in ds.durations]
+    assert stage_name in [_.stage for _ in script.durations]
     assert "duration:" in captured.out
-    assert str(ds.durations[-1].duration) in captured.out
+    assert str(script.durations[-1].duration) in captured.out
 
 
-def test__skip_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
+def test__skip_stage(
+    script: StagedScript, capsys: pytest.CaptureFixture
+) -> None:
     """Test the :func:`_skip_stage` method."""
-    ds._skip_stage()
+    script._skip_stage()
     captured = capsys.readouterr()
     assert "Skipping this stage." in captured.out
 
@@ -84,18 +90,18 @@ def test__skip_stage(ds: StagedScript, capsys: pytest.CaptureFixture) -> None:
 def test__handle_stage_retry_error(
     mock_Retrying: MagicMock,
     retry_attempts: int,
-    ds: StagedScript,
+    script: StagedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`_handle_stage_retry_error` method."""
-    ds.current_stage = "test"
-    ds.test_retry_attempts = retry_attempts
+    script.current_stage = "test"
+    script.test_retry_attempts = retry_attempts
     retry = mock_Retrying()
     retry.statistics = {
         "delay_since_first_attempt": 1234,
         "attempt_number": retry_attempts,
     }
-    ds._handle_stage_retry_error(retry)
+    script._handle_stage_retry_error(retry)
     captured = capsys.readouterr()
     if retry_attempts == 0:
         assert captured.out == ""
@@ -113,14 +119,14 @@ def test__handle_stage_retry_error(
 @patch("tenacity.RetryCallState")
 def test__prepare_to_retry_stage(
     mock_RetryCallState: MagicMock,
-    ds: StagedScript,
+    script: StagedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`_prepare_to_retry_stage` method."""
-    ds.current_stage = "test"
+    script.current_stage = "test"
     retry_state = mock_RetryCallState()
     retry_state.__repr__ = lambda self: "mock_RetryCallState.__repr__"
-    ds._prepare_to_retry_stage(retry_state)
+    script._prepare_to_retry_stage(retry_state)
     captured = capsys.readouterr()
     for text in [
         "Preparing to retry the 'test' stage...",
@@ -130,10 +136,10 @@ def test__prepare_to_retry_stage(
 
 
 def test_get_timing_report(
-    ds: StagedScript, capsys: pytest.CaptureFixture
+    script: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`_get_timing_report` method."""
-    ds.durations = [
+    script.durations = [
         StageDuration(
             "first",
             timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
@@ -143,11 +149,11 @@ def test_get_timing_report(
             timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
         )
     ]  # yapf: disable
-    ds.console.print(ds._get_timing_report())
+    script.console.print(script._get_timing_report())
     captured = capsys.readouterr()
-    for stage in [_.stage for _ in ds.durations]:
+    for stage in [_.stage for _ in script.durations]:
         assert stage in captured.out
-    for duration in [_.duration for _ in ds.durations]:
+    for duration in [_.duration for _ in script.durations]:
         assert str(duration) in captured.out
     assert "Total" in captured.out
 
@@ -165,18 +171,18 @@ def test_get_timing_report(
     ],
 )
 def test_pretty_print_command(
-    command: str, expected: str, ds: StagedScript
+    command: str, expected: str, script: StagedScript
 ) -> None:
     """Test the :func:`pretty_print_command` method."""
-    assert ds.pretty_print_command(command) == expected
+    assert script.pretty_print_command(command) == expected
 
 
-def test_parse_args(ds: StagedScript) -> None:
+def test_parse_args(script: StagedScript) -> None:
     """Test the :func:`parse_args` method."""
-    ds.stages = {"first", "second", "third"}
-    ds.parse_args(shlex.split("--dry-run --stage first third"))
-    assert ds.dry_run is True
-    assert ds.stages_to_run == {"first", "third"}
+    script.stages = {"first", "second", "third"}
+    script.parse_args(shlex.split("--dry-run --stage first third"))
+    assert script.dry_run is True
+    assert script.stages_to_run == {"first", "third"}
 
 
 @pytest.mark.parametrize("print_commands", [True, False])
@@ -184,34 +190,34 @@ def test_parse_args(ds: StagedScript) -> None:
 def test_run(
     mock_run: MagicMock,
     print_commands: bool,  # noqa: FBT001
-    ds: StagedScript,
+    script: StagedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`run` method."""
     command = "echo 'hello world'"
     mock_run.return_value = CompletedProcess(args=command, returncode=0)
-    ds.print_commands = print_commands
-    ds.run(command)
+    script.print_commands = print_commands
+    script.run(command)
     captured = capsys.readouterr()
     if print_commands:
         assert f"Executing:  {command}" in captured.out
     else:
         assert f"Executing:  {command}" not in captured.out
-    assert command in ds.commands_executed
+    assert command in script.commands_executed
 
 
 @patch("subprocess.run")
 def test_run_override_print_commands(
-    mock_run: MagicMock, ds: StagedScript, capsys: pytest.CaptureFixture
+    mock_run: MagicMock, script: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Ensure :func:`run` prints the command executed when appropriate."""
     command = "echo 'hello world'"
     mock_run.return_value = CompletedProcess(args=command, returncode=0)
-    ds.run(command, print_command=False)
+    script.run(command, print_command=False)
     captured = capsys.readouterr()
     assert f"Executing:  {command}" not in captured.out
-    ds.print_commands = False
-    ds.run(command, print_command=True)
+    script.print_commands = False
+    script.run(command, print_command=True)
     captured = capsys.readouterr()
     assert f"Executing:  {command}" in captured.out
 
@@ -235,14 +241,14 @@ def test_print_script_execution_summary(
     mock_get_pretty_command_line_invocation: MagicMock,
     extras: dict[str, str] | None,
     script_success: bool,  # noqa: FBT001
-    ds: StagedScript,
+    script: StagedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`print_script_execution_summary` method."""
     mock_get_pretty_command_line_invocation.return_value = (
         "command line invocation"
     )
-    ds.durations = [
+    script.durations = [
         StageDuration(
             "first",
             timedelta(hours=1, minutes=2, seconds=3, microseconds=4)
@@ -252,12 +258,12 @@ def test_print_script_execution_summary(
             timedelta(hours=4, minutes=3, seconds=2, microseconds=1)
         )
     ]  # yapf: disable
-    ds.commands_executed = ["foo", "bar", "baz"]
-    ds.script_success = script_success
+    script.commands_executed = ["foo", "bar", "baz"]
+    script.script_success = script_success
     if extras is None:
-        ds.print_script_execution_summary()
+        script.print_script_execution_summary()
     else:
-        ds.print_script_execution_summary(extra_sections=extras)
+        script.print_script_execution_summary(extra_sections=extras)
     captured = capsys.readouterr()
     headings = [
         "Ran the following",
@@ -267,9 +273,9 @@ def test_print_script_execution_summary(
     ]
     details = (
         [mock_get_pretty_command_line_invocation.return_value]
-        + ds.commands_executed
-        + [_.stage for _ in ds.durations]
-        + [str(_.duration) for _ in ds.durations]
+        + script.commands_executed
+        + [_.stage for _ in script.durations]
+        + [str(_.duration) for _ in script.durations]
         + ["Success" if script_success else "Failure"]
     )  # yapf: disable
     if extras is not None:
@@ -280,7 +286,7 @@ def test_print_script_execution_summary(
 
 
 def test_raise_parser_error(
-    ds: StagedScript, capsys: pytest.CaptureFixture
+    script: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`raise_parser_error` method."""
     error_message = (
@@ -289,7 +295,7 @@ def test_raise_parser_error(
         "lines."
     )
     with pytest.raises(SystemExit):
-        ds.raise_parser_error(error_message)
+        script.raise_parser_error(error_message)
     captured = capsys.readouterr()
     expected = [*error_message.split(), "usage:", "--dry-run", "--stage"]
     for term in expected:

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -33,7 +33,7 @@ def test_print_dry_run_message(
     assert expected in captured.out
 
 
-def test_validate_stage_name() -> None:
+def test__validate_stage_name() -> None:
     """Test the :func:`validate_stage_name` method."""
     StagedScript._validate_stage_name("valid")
 
@@ -42,7 +42,7 @@ def test_validate_stage_name() -> None:
     "stage_name",
     ["Uppercase", "spa ces", "hyphen-ated", "under_scores"]
 )  # yapf: disable
-def test_validate_stage_name_raises(stage_name: str) -> None:
+def test__validate_stage_name_raises(stage_name: str) -> None:
     """Ensure :func:`validate_stage_name` raises an exception when needed."""
     with pytest.raises(
         ValueError,
@@ -135,7 +135,7 @@ def test__prepare_to_retry_stage(
         assert text in captured.out
 
 
-def test_get_timing_report(
+def test__get_timing_report(
     script: StagedScript, capsys: pytest.CaptureFixture
 ) -> None:
     """Test the :func:`_get_timing_report` method."""

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -6,7 +6,7 @@ import pytest
 from rich.console import Console
 from tenacity import RetryCallState, Retrying, TryAgain
 
-from python.staged_script.staged_script.staged_script import StagedScript
+from staged_script import StagedScript
 
 
 class MyAdvancedScript(StagedScript):

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -56,7 +56,7 @@ class MyAdvancedScript(StagedScript):
 
 
 @pytest.fixture()
-def mas() -> MyAdvancedScript:
+def script() -> MyAdvancedScript:
     """Create a :class:`MyAdvancedScript` object to be used by tests."""
     my_advanced_script = MyAdvancedScript({"test"})
     my_advanced_script.console = Console(log_time=False, log_path=False)
@@ -103,7 +103,7 @@ def test_stage(  # noqa: PLR0913
     custom_skip_stage: bool,  # noqa: FBT001
     custom_end_stage: bool,  # noqa: FBT001
     custom_post_stage: bool,  # noqa: FBT001
-    mas: MyAdvancedScript,
+    script: MyAdvancedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """
@@ -111,29 +111,29 @@ def test_stage(  # noqa: PLR0913
 
     This case does not include retrying the stage.
     """
-    mas.parse_args([])
-    mas.stages_to_run = stages_to_run
+    script.parse_args([])
+    script.stages_to_run = stages_to_run
     if custom_pre_stage:
-        mas._run_pre_stage_actions_test = lambda: print(
+        script._run_pre_stage_actions_test = lambda: print(
             "inside '_run_pre_stage_actions_test' function"
         )
     if custom_begin_stage:
-        mas._begin_stage_test = lambda heading: print(
+        script._begin_stage_test = lambda heading: print(
             "inside '_begin_stage_test' function"
         )
     if custom_skip_stage:
-        mas._skip_stage_test = lambda: print(
+        script._skip_stage_test = lambda: print(
             "inside '_skip_stage_test' function"
         )
     if custom_end_stage:
-        mas._end_stage_test = lambda: print(
+        script._end_stage_test = lambda: print(
             "inside '_end_stage_test' function"
         )
     if custom_post_stage:
-        mas._run_post_stage_actions_test = lambda: print(
+        script._run_post_stage_actions_test = lambda: print(
             "inside '_run_post_stage_actions_test' function"
         )
-    mas.run_test()
+    script.run_test()
     captured = capsys.readouterr()
     index = 0
     phases = [
@@ -160,7 +160,7 @@ def test_stage_retry(
     custom_prepare_to_retry: bool,  # noqa: FBT001
     custom_handle_retry_error: bool,  # noqa: FBT001
     retry_attempts: int,
-    mas: MyAdvancedScript,
+    script: MyAdvancedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """
@@ -168,17 +168,17 @@ def test_stage_retry(
 
     This case includes retrying the stage.
     """
-    mas.parse_args(shlex.split(f"--test-retry-attempts {retry_attempts}"))
-    mas.stages_to_run = {"test"}
+    script.parse_args(shlex.split(f"--test-retry-attempts {retry_attempts}"))
+    script.stages_to_run = {"test"}
     if custom_prepare_to_retry:
-        mas._prepare_to_retry_stage_test = lambda retry_state: print(
+        script._prepare_to_retry_stage_test = lambda retry_state: print(
             "inside '_prepare_to_retry_stage_test' function"
         )
     if custom_handle_retry_error:
-        mas._handle_stage_retry_error_test = lambda retry: print(
+        script._handle_stage_retry_error_test = lambda retry: print(
             "inside '_handle_stage_retry_error_test' function"
         )
-    mas.run_test(retry=True)
+    script.run_test(retry=True)
     captured = capsys.readouterr()
     index = 0
     phases = [

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -120,24 +120,24 @@ def test_stage(  # noqa: PLR0913
     script.parse_args([])
     script.stages_to_run = stages_to_run
     if custom_pre_stage:
-        script._run_pre_stage_actions_test = lambda: print(
-            "inside '_run_pre_stage_actions_test' function"
+        script._run_pre_stage_actions_test = (  # type: ignore[attr-defined]
+            lambda: print("inside '_run_pre_stage_actions_test' function")
         )
     if custom_begin_stage:
-        script._begin_stage_test = lambda heading: print(
-            "inside '_begin_stage_test' function"
+        script._begin_stage_test = (  # type: ignore[attr-defined]
+            lambda heading: print("inside '_begin_stage_test' function")
         )
     if custom_skip_stage:
-        script._skip_stage_test = lambda: print(
+        script._skip_stage_test = lambda: print(  # type: ignore[attr-defined]
             "inside '_skip_stage_test' function"
         )
     if custom_end_stage:
-        script._end_stage_test = lambda: print(
+        script._end_stage_test = lambda: print(  # type: ignore[attr-defined]
             "inside '_end_stage_test' function"
         )
     if custom_post_stage:
-        script._run_post_stage_actions_test = lambda: print(
-            "inside '_run_post_stage_actions_test' function"
+        script._run_post_stage_actions_test = (  # type: ignore[attr-defined]
+            lambda: print("inside '_run_post_stage_actions_test' function")
         )
     script.run_test()
     captured = capsys.readouterr()
@@ -177,12 +177,16 @@ def test_stage_retry(
     script.parse_args(shlex.split(f"--test-retry-attempts {retry_attempts}"))
     script.stages_to_run = {"test"}
     if custom_prepare_to_retry:
-        script._prepare_to_retry_stage_test = lambda retry_state: print(
-            "inside '_prepare_to_retry_stage_test' function"
+        script._prepare_to_retry_stage_test = (  # type: ignore[attr-defined]
+            lambda retry_state: print(
+                "inside '_prepare_to_retry_stage_test' function"
+            )
         )
     if custom_handle_retry_error:
-        script._handle_stage_retry_error_test = lambda retry: print(
-            "inside '_handle_stage_retry_error_test' function"
+        script._handle_stage_retry_error_test = (  # type: ignore[attr-defined]
+            lambda retry: print(
+                "inside '_handle_stage_retry_error_test' function"
+            )
         )
     script.run_test(retry=True)
     captured = capsys.readouterr()

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -1,5 +1,11 @@
 """Integration tests for an advanced ``staged-script`` use case."""
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import shlex
 
 import pytest

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -1,5 +1,11 @@
 """Integration tests for a basic ``StagedScript`` use case."""
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import pytest
 from rich.console import Console
 

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -34,7 +34,7 @@ class MyBasicScript(StagedScript):
 
 
 @pytest.fixture()
-def mbs() -> MyBasicScript:
+def script() -> MyBasicScript:
     """Create a :class:`MyBasicScript` object to be used by tests."""
     my_basic_script = MyBasicScript({"good", "bad"})
     my_basic_script.console = Console(log_time=False, log_path=False)
@@ -43,12 +43,14 @@ def mbs() -> MyBasicScript:
 
 @pytest.mark.parametrize("stages_to_run", [{"good"}, set()])
 def test_good_stage(
-    stages_to_run: set[str], mbs: MyBasicScript, capsys: pytest.CaptureFixture
+    stages_to_run: set[str],
+    script: MyBasicScript,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     """Ensure the good stage runs to completion."""
-    mbs.parse_args([])
-    mbs.stages_to_run = stages_to_run
-    mbs.run_good_stage()
+    script.parse_args([])
+    script.stages_to_run = stages_to_run
+    script.run_good_stage()
     captured = capsys.readouterr()
 
     # Ensure `_begin_stage()` is called.
@@ -67,7 +69,7 @@ def test_good_stage(
 @pytest.mark.parametrize("error", [True, False])
 def test_bad_stage(
     error: bool,  # noqa: FBT001
-    mbs: MyBasicScript,
+    script: MyBasicScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """
@@ -76,15 +78,15 @@ def test_bad_stage(
     If there's no error, it runs to completion; otherwise it bugs out in
     the stage body, but still runs the end-stage actions.
     """
-    mbs.parse_args([])
-    mbs.stages_to_run = {"bad"}
+    script.parse_args([])
+    script.stages_to_run = {"bad"}
     if error:
         with pytest.raises(RuntimeError) as e:
-            mbs.run_bad_stage(error=error)
+            script.run_bad_stage(error=error)
         msg = e.value.args[0]
         assert "Something went wrong." in msg
     else:
-        mbs.run_bad_stage(error=error)
+        script.run_bad_stage(error=error)
     captured = capsys.readouterr()
 
     # Ensure `_begin_stage()` is called.
@@ -101,9 +103,9 @@ def test_bad_stage(
 
 
 @pytest.mark.parametrize("stage", ["good", "bad"])
-def test_parser_retry_options(stage: str, mbs: MyBasicScript) -> None:
+def test_parser_retry_options(stage: str, script: MyBasicScript) -> None:
     """Ensure the stage retry options are present."""
-    help_text = mbs.parser.format_help()
+    help_text = script.parser.format_help()
     assert f"--{stage}-retry-attempts" in help_text
     assert f"--{stage}-retry-delay" in help_text
     assert f"--{stage}-retry-timeout" in help_text

--- a/test/test_staged_script_basic_subclass.py
+++ b/test/test_staged_script_basic_subclass.py
@@ -3,7 +3,7 @@
 import pytest
 from rich.console import Console
 
-from python.staged_script.staged_script.staged_script import StagedScript
+from staged_script import StagedScript
 
 
 class MyBasicScript(StagedScript):

--- a/test/test_staged_script_registered_stages.py
+++ b/test/test_staged_script_registered_stages.py
@@ -1,6 +1,6 @@
 """Integration tests for retry options."""
 
-from python.staged_script.staged_script.staged_script import StagedScript
+from staged_script import StagedScript
 
 
 class MyScript(StagedScript):

--- a/test/test_staged_script_registered_stages.py
+++ b/test/test_staged_script_registered_stages.py
@@ -1,5 +1,11 @@
 """Integration tests for retry options."""
 
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from staged_script import StagedScript
 
 


### PR DESCRIPTION
**Type:  Refactor**

## Commits
1. **test: Rename test fixtures** (5f7b06329b07dfdc8a773889bf5c9ee8c910ac59)

   Remove acronyms for clarity.
1. **test: Rename tests** (27233514efb2797f8f8fe8e561d9377bbb9677e3)

   The convention is to name tests `test_<function_to_test>`, but these tests accidentally omitted the leading underscore.
1. **chore: Remove YAPF comments** (86f5cfeb2886f25a3cef9dd7035e635748038a9d)

   No longer needed after switching from YAPF to Ruff.
1. **test: Fix imports for unit/integration tests** (e1836e31a7c56d33d77b8c1736d147d279105e17)
1. **refactor: Reduce setup file** (b23355399007e17f023750d33a46020b33b817fb)

   Remove the guts of the `setup.py` file so it just uses the `pyproject.toml` under the hood.
1. **chore: Add version to __init__.py** (f42f22d4a8e2dc553ffe2ec0df039078ffb45772)
1. **docs: Add copyright/license text to source files** (b0c22fcc011cb77ffada7d8614f63e435774818e)
1. **chore: Ignore mypy warnings** (4dbf516b868d68471e7eb0e79d835b832743d6a2)

   Temporarily disable these warnings until there's time to revisit and address them.