### PR TITLE
Add dry run test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,35 @@
+[run]
+omit =
+    test/*
+    */.vscode/*
+branch = True
+dynamic_context = test_function
+relative_files = True
+
+[paths]
+source = staged_script
+
+[report]
+skip_covered = False
+fail_under = 100
+show_missing = True
+exclude_lines =
+    pragma: no cover
+    if 0:
+    if False:
+
+[html]
+directory = test/htmlcov
+title = staged-script Coverage Report
+show_contexts = True
+
+[xml]
+output = test/coverage.xml
+
+[json]
+output = test/coverage.json
+pretty_print = True
+show_contexts = True
+
+[lcov]
+output = test/coverage.lcov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
     steps:
 
       - name: Check out the commit

--- a/staged_script/__init__.py
+++ b/staged_script/__init__.py
@@ -16,7 +16,6 @@ from .staged_script import (
     HelpFormatter,
     RetryStage,
     StageDuration,
-    lazy_property,
 )
 
 __all__ = [
@@ -24,6 +23,5 @@ __all__ = [
     "HelpFormatter",
     "RetryStage",
     "StageDuration",
-    "lazy_property",
 ]
 __version__ = "1.0.0"

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -41,33 +41,6 @@ from tenacity.wait import wait_fixed
 rich.traceback.install()
 
 
-def lazy_property(func: Callable) -> property:
-    """
-    A decorator to make it such that a property is lazily evaluated.
-
-    When the property is first accessed, the object will not yet have a
-    corresponding attribute, so the value will be computed by executing
-    :arg:`func`.  Any time the property is accessed thereafter, the
-    value will just be retrieved from the object's corresponding
-    attribute.
-
-    Args:
-        func:  The function used to compute the value of the property.
-
-    Returns:
-        The lazy property decorator.
-    """
-    attr_name = f"_lazy_{func.__name__}"
-
-    @property  # type: ignore[misc]
-    def _lazy_property(self):
-        if not hasattr(self, attr_name):
-            setattr(self, attr_name, func(self))
-        return getattr(self, attr_name)
-
-    return _lazy_property  # type: ignore[return-value]
-
-
 class StageDuration(NamedTuple):
     """
     The duration of a stage.
@@ -250,7 +223,7 @@ class StagedScript:
     # Parse the command line arguments.
     #
 
-    @lazy_property
+    @functools.cached_property
     def parser(self) -> ArgumentParser:
         """
         The base argument parser.
@@ -261,7 +234,7 @@ class StagedScript:
 
         .. code-block:: python
 
-            @lazy_property
+            @functools.cached_property
             def parser(self) -> ArgumentParser:
                 ap = super().parser
                 ap.description = '''INSERT DESCRIPTION HERE'''

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -223,6 +223,18 @@ def test_run_override_print_commands(
     assert f"Executing:  {command}" in captured.out
 
 
+def test_run_dry_run(
+    script: StagedScript, capsys: pytest.CaptureFixture
+) -> None:
+    """Test the :func:`run` method in dry-run mode."""
+    command = "echo 'dry-run mode'"
+    script.dry_run = True
+    script.run(command)
+    captured = capsys.readouterr()
+    for _ in ["The command executed would be", command]:
+        assert _ in captured.out
+
+
 @pytest.mark.parametrize("script_success", [True, False])
 @pytest.mark.parametrize(
     "extras",


### PR DESCRIPTION
**Type:  Task**

## Commits
1. **ci: Don't fail fast** (0d3a5e3a2a1b41d8dc11a3c7b7ec2a4a67c9fd98)

   If one job in the matrix of jobs fails, we still want to be able to see the results from the other jobs.
1. **refactor: Use functools.cached_property instead** (3d91282518331e91c650f6c76815b2cf5b18e030)

   This package was originally developed for Python 3.6, before `functools.cached_property` was introduced.  That should be a drop-in replacement for the home-grown `lazy_property`, though, so now that we just support Python 3.8+, we should use it instead.
1. **test: Add coverage configuration** (27bc6d62408a42b4b99b5d5634890595454d3d0b)
1. **test: Cover `run()` in dry-run mode** (c44d6ffb2b7965c0b4ee460b167c0af2b51a20fa)

## Motivation
Just wanting complete unit test coverage for safety's sake.
