### PR TITLE
docs: Pin Sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `staged-script` documentation.
 
-sphinx
+sphinx<8.0.0
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-rtd-theme


### PR DESCRIPTION
**Type:  Documentation**

## Description
The Sphinx 8.0.0 release causes problems with sphinx-rtd-theme, so I'm pinning Sphinx below 8.0 to get things back up and running again.

## Related Issues/PRs
The problem first showed up in #95.