### PR TITLE
chore: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,23 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      github-actions-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
-    directory: /doc
+    directories:
+      - /
+      - /doc
+      - /example
+      - /test
     schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /example
-    schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /test
-    schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      python-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
**Type:  Task**

## Description
Run dependabot updates weekly instead of daily, and group them together for the different providers (GitHub Actions and pip), to reduce the amount of noise in the repository history.

## Related Issues/PRs
I worked out the details here in:
* https://github.com/sandialabs/reverse_argparse/pull/225
* https://github.com/sandialabs/reverse_argparse/pull/223