### PR TITLE
Update ruff linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.12.2
       hooks:
-        - id: ruff
+        - id: ruff-check
         - id: ruff-format
 
     - repo: https://github.com/gitleaks/gitleaks

--- a/example/ex_6_creating_retryable_stages.py
+++ b/example/ex_6_creating_retryable_stages.py
@@ -7,6 +7,8 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import argparse
 import functools
 import sys

--- a/example/ex_6_creating_retryable_stages.py
+++ b/example/ex_6_creating_retryable_stages.py
@@ -27,7 +27,7 @@ class MyScript(StagedScript):
         console_force_terminal: Optional[bool] = None,
         console_log_path: bool = True,
         print_commands: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             stages,
             console_force_terminal=console_force_terminal,

--- a/example/ex_7_customizing_the_summary.py
+++ b/example/ex_7_customizing_the_summary.py
@@ -7,6 +7,8 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import argparse
 import functools
 import platform

--- a/example/ex_7_customizing_the_summary.py
+++ b/example/ex_7_customizing_the_summary.py
@@ -29,7 +29,7 @@ class MyScript(StagedScript):
         console_force_terminal: Optional[bool] = None,
         console_log_path: bool = True,
         print_commands: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             stages,
             console_force_terminal=console_force_terminal,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ line-length = 79
 extend-select = [
     "A",
     "AIR",
-    # "ANN",
+    "ANN",
     "ARG",
     "ASYNC",
     "B",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ extend-select = [
     "RUF",
     "S",
     "SIM",
-    # "SLF",
+    "SLF",
     "SLOT",
     "T10",
     "T20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,32 +73,61 @@ line-length = 79
 [tool.ruff.lint]
 extend-select = [
     "A",
+    "AIR",
+    # "ANN",
+    "ARG",
+    "ASYNC",
     "B",
     "BLE",
     "C4",
     "C90",
     "D",
+    "DJ",
     "DTZ",
     "E",
     "EM",
     "ERA",
     "EXE",
+    "F",
+    "FA",
     "FBT",
+    "FIX",
+    "FLY",
+    "FURB",
+    "G",
+    "ICN",
+    "INP",
+    "INT",
+    "ISC",
+    "LOG",
+    "N",
     "NPY",
+    "PD",
+    "PERF",
     "PGH",
+    "PIE",
     "PL",
     "PT",
     "PTH",
+    "PYI",
+    "Q",
     "RET",
     "RSE",
     "RUF",
     "S",
     "SIM",
+    # "SLF",
+    "SLOT",
+    "T10",
+    "T20",
+    "TC",
+    "TD",
     "TID",
     "TCH",
     "TRY",
     "UP",
     "W",
+    "YTT",
 ]
 ignore = [
     "D212",
@@ -106,7 +135,12 @@ ignore = [
 
 
 [tool.ruff.lint.per-file-ignores]
-"**/test_*.py" = ["S101"]
+"**/test_*.py" = [
+    "S101",
+    "SLF001",
+    "T201",
+]
+"doc/source/conf.py" = ["INP001"]
 "example/*.py" = [
     "D101",
     "D102",
@@ -119,6 +153,10 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
 
 
 [tool.semantic_release]

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -11,6 +11,8 @@ your own staged scripts, along with some helpers.
 
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import functools
 import re
 import shlex
@@ -365,7 +367,6 @@ class StagedScript:
         were met before attempting the stage, and erroring out
         appropriately if not.
         """
-        pass
 
     def _begin_stage(self, heading: str) -> None:
         """
@@ -495,7 +496,6 @@ class StagedScript:
         were met before moving on, and erroring out appropriately if
         not.
         """
-        pass
 
     def _prepare_to_retry_stage(self, retry_state: RetryCallState) -> None:
         """
@@ -1023,8 +1023,6 @@ class RetryStage(TryAgain):
     that a stage should be retried.
     """
 
-    pass
-
 
 class HelpFormatter(
     ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter
@@ -1036,5 +1034,3 @@ class HelpFormatter(
     treats the description as raw text (doesn't do any automatic
     formatting) and shows default values of arguments.
     """
-
-    pass

--- a/staged_script/staged_script.py
+++ b/staged_script/staged_script.py
@@ -26,7 +26,7 @@ from argparse import (
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from subprocess import CompletedProcess
-from typing import Callable, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, NoReturn, Optional
 
 import __main__
 import rich.traceback
@@ -145,7 +145,7 @@ class StagedScript:
         console_force_terminal: Optional[bool] = None,
         console_log_path: bool = True,
         print_commands: bool = True,
-    ):
+    ) -> None:
         """
         Initialize a :class:`StagedScript` object.
 
@@ -248,7 +248,7 @@ class StagedScript:
 
         def decorator(func: Callable) -> Callable:
             def get_phase_method(  # noqa: D417
-                self,
+                self,  # noqa: ANN001
                 method_name: str,
             ) -> Callable:
                 """
@@ -273,9 +273,9 @@ class StagedScript:
                 )
 
             def run_retryable_phases(  # noqa: D417
-                self,
-                *args,
-                **kwargs,
+                self,  # noqa: ANN001
+                *args: Any,  # noqa: ANN401
+                **kwargs: Any,  # noqa: ANN401
             ) -> None:
                 """
                 Run the retryable phases.
@@ -310,7 +310,7 @@ class StagedScript:
                 get_phase_method(self, "_end_stage")()
 
             @functools.wraps(func)
-            def wrapper(self, *args, **kwargs) -> None:
+            def wrapper(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN001, ANN401
                 """
                 Turn a function into a stage.
 
@@ -759,7 +759,7 @@ class StagedScript:
             ]:
                 setattr(self, retry_arg, getattr(self.args, retry_arg, None))
 
-    def raise_parser_error(self, message):
+    def raise_parser_error(self, message: str) -> NoReturn:
         """
         Raise a parser error.
 
@@ -788,7 +788,7 @@ class StagedScript:
         *,
         pretty_print: bool = False,
         print_command: Optional[bool] = None,
-        **kwargs,
+        **kwargs: Any,  # noqa: ANN401
     ) -> CompletedProcess:
         """
         Run a command in the underlying shell.

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -18,6 +18,7 @@ import pytest
 from rich.console import Console
 
 from staged_script import StagedScript, StageDuration
+from staged_script.staged_script import validate_stage_name
 
 
 @pytest.fixture
@@ -39,21 +40,21 @@ def test_print_dry_run_message(
     assert expected in captured.out
 
 
-def test__validate_stage_name() -> None:
-    """Test the :func:`validate_stage_name` method."""
-    StagedScript._validate_stage_name("valid")
+def test_validate_stage_name() -> None:
+    """Test the :func:`validate_stage_name` function."""
+    validate_stage_name("valid")
 
 
 @pytest.mark.parametrize(
     "stage_name", ["Uppercase", "spa ces", "hyphen-ated", "under_scores"]
 )
-def test__validate_stage_name_raises(stage_name: str) -> None:
+def test_validate_stage_name_raises(stage_name: str) -> None:
     """Ensure :func:`validate_stage_name` raises an exception when needed."""
     with pytest.raises(
         ValueError,
         match=f"'{stage_name}' must contain only lowercase letters",
     ):
-        StagedScript._validate_stage_name(stage_name)
+        validate_stage_name(stage_name)
 
 
 def test__begin_stage(

--- a/test/test_staged_script.py
+++ b/test/test_staged_script.py
@@ -6,6 +6,8 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import shlex
 from datetime import datetime, timedelta, timezone
 from subprocess import CompletedProcess
@@ -91,7 +93,7 @@ def test__skip_stage(
 @pytest.mark.parametrize("retry_attempts", [0, 5])
 @patch("tenacity.Retrying")
 def test__handle_stage_retry_error(
-    mock_Retrying: MagicMock,
+    mock_retrying: MagicMock,
     retry_attempts: int,
     script: StagedScript,
     capsys: pytest.CaptureFixture,
@@ -99,7 +101,7 @@ def test__handle_stage_retry_error(
     """Test the :func:`_handle_stage_retry_error` method."""
     script.current_stage = "test"
     script.test_retry_attempts = retry_attempts  # type: ignore[attr-defined]
-    retry = mock_Retrying()
+    retry = mock_retrying()
     retry.statistics = {
         "delay_since_first_attempt": 1234,
         "attempt_number": retry_attempts,
@@ -121,14 +123,14 @@ def test__handle_stage_retry_error(
 
 @patch("tenacity.RetryCallState")
 def test__prepare_to_retry_stage(
-    mock_RetryCallState: MagicMock,
+    mock_retry_call_state: MagicMock,
     script: StagedScript,
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Test the :func:`_prepare_to_retry_stage` method."""
     script.current_stage = "test"
-    retry_state = mock_RetryCallState()
-    retry_state.__repr__ = lambda self: "mock_RetryCallState.__repr__"
+    retry_state = mock_retry_call_state()
+    retry_state.__repr__ = lambda _self: "mock_RetryCallState.__repr__"
     script._prepare_to_retry_stage(retry_state)
     captured = capsys.readouterr()
     for text in [

--- a/test/test_staged_script_advanced_subclass.py
+++ b/test/test_staged_script_advanced_subclass.py
@@ -42,7 +42,7 @@ class MyAdvancedScript(StagedScript):
     def _run_pre_stage_actions(self) -> None:
         print("inside '_run_pre_stage_actions' function")
 
-    def _begin_stage(self, heading: str) -> None:
+    def _begin_stage(self, _heading: str) -> None:
         print("inside '_begin_stage' function")
 
     def _skip_stage(self) -> None:
@@ -54,10 +54,10 @@ class MyAdvancedScript(StagedScript):
     def _run_post_stage_actions(self) -> None:
         print("inside '_run_post_stage_actions' function")
 
-    def _handle_stage_retry_error(self, retry: Retrying) -> None:
+    def _handle_stage_retry_error(self, _retry: Retrying) -> None:
         print("inside '_handle_stage_retry_error' function")
 
-    def _prepare_to_retry_stage(self, retry_state: RetryCallState) -> None:
+    def _prepare_to_retry_stage(self, _retry_state: RetryCallState) -> None:
         print("inside '_prepare_to_retry_stage' function")
 
 
@@ -125,7 +125,7 @@ def test_stage(  # noqa: PLR0913
         )
     if custom_begin_stage:
         script._begin_stage_test = (  # type: ignore[attr-defined]
-            lambda heading: print("inside '_begin_stage_test' function")
+            lambda _heading: print("inside '_begin_stage_test' function")
         )
     if custom_skip_stage:
         script._skip_stage_test = lambda: print(  # type: ignore[attr-defined]
@@ -178,13 +178,13 @@ def test_stage_retry(
     script.stages_to_run = {"test"}
     if custom_prepare_to_retry:
         script._prepare_to_retry_stage_test = (  # type: ignore[attr-defined]
-            lambda retry_state: print(
+            lambda _retry_state: print(
                 "inside '_prepare_to_retry_stage_test' function"
             )
         )
     if custom_handle_retry_error:
         script._handle_stage_retry_error_test = (  # type: ignore[attr-defined]
-            lambda retry: print(
+            lambda _retry: print(
                 "inside '_handle_stage_retry_error_test' function"
             )
         )


### PR DESCRIPTION
**Type:  Task**

## Description
Turn on all the latest and greatest Ruff linters, and adjust the code as needed to make them pass.

## Summary by Sourcery

Enable all new Ruff linter rules and adjust the codebase, examples, and tests to satisfy updated lint and type requirements.

Enhancements:
- Centralise stage name validation into a standalone function and replace the old static validator
- Add type hints and return annotations across methods and functions
- Remove redundant no-op pass statements in various classes
- Update example scripts to include explicit return type annotations

Build:
- Extend Ruff linting rules and per-file ignores in pyproject.toml
- Add pyupgrade configuration to preserve runtime typing

CI:
- Update pre-commit configuration to use the ruff-check hook

Tests:
- Rename and update tests to call the new validate_stage_name function and adjust mock variable names
- Add type annotations to test parameters and kwargs