### PR TITLE
patch: Drop support for Python 3.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/staged-script/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/staged-script/master)
 [![PyPI - Version](https://img.shields.io/pypi/v/staged-script?label=PyPI)](https://pypi.org/project/staged-script/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/staged-script?label=PyPI%20downloads)
-![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13|3.14-blue.svg)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 # staged-script

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -54,7 +54,7 @@
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/staged-script?label=PyPI
    :target: https://pypi.org/project/staged-script/
 .. |PyPI Downloads| image:: https://img.shields.io/pypi/dm/staged-script?label=PyPI%20downloads
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13|3.14-blue.svg
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Documentation",
@@ -60,7 +60,7 @@ Issues = "https://github.com/sandialabs/staged-script/issues"
 
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 reverse-argparse = "*"
 rich = "*"
 tenacity = "*"


### PR DESCRIPTION
Also add support for Python 3.14.

## Summary by Sourcery

Drop support for Python 3.9, bump minimum Python requirement to 3.10, and add support for Python 3.14 across packaging, CI, and documentation.

Enhancements:
- Update pyproject.toml to require Python >=3.10, remove Python 3.9 classifier, and add Python 3.14 classifier
- Update GitHub Actions matrix to test on Python 3.10–3.14 instead of 3.9–3.13
- Refresh README Python version badge to reflect support for 3.10–3.14