### PR TITLE
docs: Downgrade Sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `staged-script` documentation.
 
-sphinx<=9.0.0
+sphinx<9.0.0
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-rtd-theme


### PR DESCRIPTION
Should have been included in b17bd9d082e952bfe61b3f49c1c3f66c9217a876.
