### PR TITLE
docs: Unpin Sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `staged-script` documentation.
 
-sphinx<9.0.0
+sphinx
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-rtd-theme


### PR DESCRIPTION
The various Sphinx extensions have all updated to deal with the breaking changes in 9.0.0.  This effectively reverts both
c87e07692e7e35a78fb806bf217deb3540b9aab8 and
b17bd9d082e952bfe61b3f49c1c3f66c9217a876.
