### PR TITLE
docs: reference template method pattern

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -188,11 +188,7 @@ the stages as they run.  Recall from
 number of phases, each of which has a corresponding method.  These phase
 methods have reasonable :ref:`default implementations
 <stage_customization>` in the base class, but may be extended or
-overridden in your subclasses.  If you're familiar with software design
-patterns, this overall structure follows the `Template Method pattern
-<https://refactoring.guru/design-patterns/template-method>`_: the base
-class defines the high-level algorithm for running a stage, while
-subclasses customize selected steps in that flow.
+overridden in your subclasses.
 
 .. literalinclude:: ../../example/ex_4_customizing_stage_behavior.py
    :language: python

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -188,7 +188,11 @@ the stages as they run.  Recall from
 number of phases, each of which has a corresponding method.  These phase
 methods have reasonable :ref:`default implementations
 <stage_customization>` in the base class, but may be extended or
-overridden in your subclasses.
+overridden in your subclasses.  If you're familiar with software design
+patterns, this overall structure follows the `Template Method pattern
+<https://refactoring.guru/design-patterns/template-method>`_: the base
+class defines the high-level algorithm for running a stage, while
+subclasses customize selected steps in that flow.
 
 .. literalinclude:: ../../example/ex_4_customizing_stage_behavior.py
    :language: python

--- a/doc/source/features/stage-implementation-details.rst
+++ b/doc/source/features/stage-implementation-details.rst
@@ -126,7 +126,8 @@ customizing):
    You can zoom and pan in the image above.
 
 If you're familiar with software design patterns, this overall structure
-follows the `Template Method pattern
-<https://refactoring.guru/design-patterns/template-method>`_: the base
-class defines the high-level algorithm for running a stage, while
-subclasses customize selected steps in that flow.
+follows the `Template Method pattern`_:  the base class defines the
+high-level algorithm for running a stage, while subclasses customize
+selected steps in that flow.
+
+.. _Template Method pattern:  https://refactoring.guru/design-patterns/template-method

--- a/doc/source/features/stage-implementation-details.rst
+++ b/doc/source/features/stage-implementation-details.rst
@@ -124,3 +124,9 @@ customizing):
 .. note::
 
    You can zoom and pan in the image above.
+
+If you're familiar with software design patterns, this overall structure
+follows the `Template Method pattern
+<https://refactoring.guru/design-patterns/template-method>`_: the base
+class defines the high-level algorithm for running a stage, while
+subclasses customize selected steps in that flow.


### PR DESCRIPTION
## Summary
Add a short note to the stage customization docs explaining that `StagedScript` follows the Template Method pattern.

## Related Issue
Closes #105

## What changed
- Added a brief explanation in the “Customizing Stage Behavior” docs section.
- Linked to a concise external reference for the Template Method pattern.

## Validation
- Reviewed the updated docs text in context.
- Ran `git diff --check`.
- I was not able to run the repo's Python tooling locally in this checkout because `pytest` and `ruff` are not currently installed in this environment.

## Summary by Sourcery

Document the Template Method pattern usage in stage customization examples.

Documentation:
- Add a brief explanation in the stage customization docs that StagedScript follows the Template Method design pattern.
- Link to an external reference describing the Template Method pattern from the stage customization documentation.